### PR TITLE
base64 encode version token

### DIFF
--- a/api.go
+++ b/api.go
@@ -110,8 +110,8 @@ func (a *netAPI) ListUpdate(ctx context.Context, threatType pb.ThreatType, versi
 	// Add fields from ComputeThreatListDiffRequest to URL request
 	q := u.Query()
 	q.Set(threatTypeString, threatType.String())
-	if string(versionToken) != "" {
-		q.Set(versionTokenString, string(versionToken))
+	if len(versionToken) != 0 {
+		q.Set(versionTokenString, base64.StdEncoding.EncodeToString(versionToken))
 	}
 	for _, compressionType := range compressionTypes {
 		q.Add(supportedCompressionsString, compressionType.String())


### PR DESCRIPTION
**Background**
https://github.com/google/webrisk/issues/16#issuecomment-599298849

**Changes**
- base64 encode `versionToken` as specified by [the api docs](https://cloud.google.com/web-risk/docs/reference/rest/v1/threatLists/computeDiff#query-parameters)
