### PR TITLE
Adds support for running WebRisk Proxy Server as a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM golang:alpine
+
+
+WORKDIR /go/src/webrisk
+
+
+RUN apk add --update --no-cache git
+
+
+# Gets the Proxy server binary
+RUN go get github.com/google/webrisk/cmd/wrserver
+
+
+# If you want to run a container with a different API KEY you can just
+# pass this variable as `docker run` argument:
+# docker run -e WR_API_KEY=XXXXXXXXXXXXXXXXXXXXXXXX
+ARG WR_API_KEY
+
+
+# If you want to change the Proxy server port you can pass this
+# variable as `docker run` argument:
+# docker run -e WR_PROXY_PORT=5000
+ARG WR_PROXY_PORT
+
+
+# In case no WR_PROXY_PORT is informed, default value is 8080
+ENV WR_PROXY_PORT=8080
+
+
+# Runs the WebRisk Proxy Server
+CMD /go/bin/wrserver \
+        -apikey=${WR_API_KEY} \
+        -srvaddr=0.0.0.0:${WR_PROXY_PORT} \
+        -db=/tmp/webrisk.db

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ To use the local proxy server to check a URL, send a POST request to `127.0.0.1:
           ]
         }
 	```
+4. Or, if you would like to run the Proxy server as a container you can do as follows:
+```bash
+$> docker build --tag webrisk:local .
+```
+Once the image is built locally, you can run it:
+```bash
+$> docker run -it --rm -p 8080:8080 -e WR_API_KEY=XXXXXXXXXXX --name webrisk webrisk:local
+```
 
 # Command-Line Lookup
 


### PR DESCRIPTION
Hi, folks. 

This Pull Request tries to contribute adding the capability of running  the WebRisk Proxy server
as a Docker container. It has the following contributions:

* Creates a `Dockerfile` which instructs how to build a docker image with the WebRisk Proxy Server;
* Adds documentation on the project Readme explaining how to build  and run a container;

This docker image allows two runtime environment variables:

* `WR_API_KEY`: For informing at container runtime/load the Google API key to be used by the WR Proxy server;
* `WR_PROXY_PORT`: For allowing the user to modify which port the container is going to bind the WR Proxy server;

I believe this contribution can help new comers or new users of the WebRisk API to get started 
and try it in their environments.

---

If you folks think this contribution makes sense to this project, I would suggest to automatically build
this docker image in a regular and automated basis and make it available at [Google DockerHub](https://hub.docker.com/u/google) namespace. 
 
With that, users could easily try the WebRisk Proxy Server by simply running:
```bash
$> docker run -p 8080:8080 -e WR_API_KEY=XXX google/webrisk
```

All the best, and thank you for this project.