### PR TITLE
Update Dockerfile - prevent runtime/cgo: pthread_create failed: Opera…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as build
+FROM golang:1.19.1 as build
 
 WORKDIR /go/src/webrisk
 


### PR DESCRIPTION
golang version 1.19 causes the below error -

runtime/cgo: pthread_create failed: Operation not permitted

bumping version fixes the error